### PR TITLE
Dockerfile.template: Use slim golang image

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM resin/%%RESIN_MACHINE_NAME%%-golang
+FROM resin/%%RESIN_MACHINE_NAME%%-golang:slim
 
 ENV INITSYSTEM on
 


### PR DESCRIPTION
This reduces the size of the example image from ~770MB to ~550MB.