### PR TITLE
meta: Adding codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @garethtdavies


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Gareth Davies <gareth@balena.io>