### PR TITLE
Initial default go module when building

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -4,6 +4,8 @@ WORKDIR /go/src/github.com/balena-io-projects/app
 
 COPY /app ./
 
+RUN go mod init
+
 RUN go build
 
 FROM balenalib/%%BALENA_MACHINE_NAME%%-debian:stretch

--- a/repo.yml
+++ b/repo.yml
@@ -1,0 +1,1 @@
+type: generic


### PR DESCRIPTION
starting with Go 1.16 the build command would automagically resolve any issues with go.mod but now it does not and therefore builds will fail with `go: go.mod file not found in current directory or any parent directory; see 'go help modules'`.

This fixes that by init a default module.